### PR TITLE
atomic-primops.cabal: allow base-4.7.0.1 (ghc-7.8.3)

### DIFF
--- a/atomic-primops/atomic-primops.cabal
+++ b/atomic-primops/atomic-primops.cabal
@@ -96,7 +96,7 @@ Library
 
   -- casMutVar# had a bug in GHC 7.2, thus we require GHC 7.4 or greater
   -- (base 4.5 or greater). We also need the "Any" kind.
-  build-depends:     base >= 4.6.0.0 && <= 4.7.0.0, ghc-prim, primitive
+  build-depends:     base >= 4.6.0.0 && < 4.8.0.0, ghc-prim, primitive
 
   -- TODO: Try to push support back to 7.0, but make it default to an implementation
   -- other than Unboxed.


### PR DESCRIPTION
'<=' upper bound constraint is almost never correct
(unless one workarounds some known bug, then a link would help)

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
