### PR TITLE
New 7.10 primops (sans atomic read/write, and CAS on small bytearrays)

### DIFF
--- a/atomic-primops/Data/Atomics.hs
+++ b/atomic-primops/Data/Atomics.hs
@@ -30,9 +30,9 @@ module Data.Atomics
    fetchNandIntArray,
    fetchOrIntArray,
    fetchXorIntArray,
-   -- ** Reading and writing with barriers
-   atomicReadIntArray,
-   atomicWriteIntArray,
+   -- -- ** Reading and writing with barriers
+   -- atomicReadIntArray,
+   -- atomicWriteIntArray,
       
    -- * Atomic operations on raw MutVars
    -- | A lower-level version of the IORef interface.
@@ -71,13 +71,6 @@ import GHC.Word (Word(W#))
 -- for fetch* family function fallbacks:
 import Data.Bits
 
--- imports for GHC < 7.10 conditionals below.
-#if MIN_VERSION_base(4,8,0)
-#else
-import Control.Monad (void)
-import Data.Primitive.ByteArray (writeByteArray)
-#endif 
-
 
 #ifdef DEBUG_ATOMICS
 #warning "Activating DEBUG_ATOMICS... NOINLINE's and more"
@@ -99,8 +92,6 @@ import Data.Primitive.ByteArray (writeByteArray)
 {-# NOINLINE fetchNandIntArray #-}
 {-# NOINLINE fetchOrIntArray #-}
 {-# NOINLINE fetchXorIntArray #-}
-{-# NOINLINE atomicReadIntArray #-}
-{-# NOINLINE atomicWriteIntArray #-}
 #else
 {-# INLINE casIORef #-}
 {-# INLINE casArrayElem2 #-}   
@@ -117,8 +108,6 @@ import Data.Primitive.ByteArray (writeByteArray)
 {-# INLINE fetchNandIntArray #-}
 {-# INLINE fetchOrIntArray #-}
 {-# INLINE fetchXorIntArray #-}
-{-# INLINE atomicReadIntArray #-}
-{-# INLINE atomicWriteIntArray #-}
 #endif
 
 
@@ -290,6 +279,17 @@ fetchAddByteArrayInt (MutableByteArray mba#) (I# offset#) (I# incr#) = IO $ \ s1
 
 
 --------------------------------------------------------------------------------
+{- WIP. Having trouble writing good tests for these, and not sure how useful
+ - these are. See #43 discussion
+ -
+ - Also remember to add these to the INLINE / NOINLINE section when exported
+
+-- imports for GHC < 7.10 conditionals below.
+#if MIN_VERSION_base(4,8,0)
+#else
+import Control.Monad (void)
+import Data.Primitive.ByteArray (writeByteArray)
+#endif 
 
 
 -- | Given an array and an offset in Int units, read an element. The index is
@@ -325,6 +325,7 @@ atomicWriteIntArray mba ix n = do
 {-# WARNING atomicWriteIntArray "atomicWriteIntArray is likely to be very slow on GHC <7.10. Consider using writeByteArray along with one of the barriers exposed here instead" #-}
 #endif
 
+-}
 
 --------------------------------------------------------------------------------
 

--- a/atomic-primops/Data/Atomics/Counter.hs
+++ b/atomic-primops/Data/Atomics/Counter.hs
@@ -154,5 +154,7 @@ incrCounter (I# incr#) (AtomicCounter mba#) = IO $ \ s1# ->
 -- | An alternate version for when you don't care about the old value.
 incrCounter_ :: Int -> AtomicCounter -> IO ()
 incrCounter_ (I# incr#) (AtomicCounter mba#) = IO $ \ s1# -> 
+  -- NOTE: either old or new behavior of fetchAddIntArray# is fine here, since
+  -- we don't inspect the return value:
   let (# s2#, res #) = fetchAddIntArray# mba# 0# incr# s1# in
   (# s2#, () #)

--- a/atomic-primops/testing/CommonTesting.hs
+++ b/atomic-primops/testing/CommonTesting.hs
@@ -13,7 +13,7 @@ import GHC.IO (unsafePerformIO)
 import System.CPUTime
 import System.Mem.StableName (makeStableName, hashStableName)
 import System.Environment (getEnvironment)
-import System.IO        (stdout, stderr, hPutStrLn, hFlush)
+import System.IO        (stderr, hPutStrLn, hFlush)
 import Debug.Trace      (trace)
 
 -- import Test.Framework.TH (defaultMainGenerator)
@@ -84,7 +84,7 @@ cputime a = do
     start <- getCPUTime
     v <- a
     end   <- getCPUTime
-    let diff = (fromIntegral (end - start)) / (10^12)
+    let diff = (fromIntegral (end - start)) / (10^(12::Int))
     printf "SELFTIMED: %0.3f sec\n" (diff :: Double)
     return v
 
@@ -106,7 +106,7 @@ nTimes :: Int -> IO () -> IO ()
 --
 --  INLINE should not affect recursive functions.  But here it seems to have a
 --  deleterious effect!
-nTimes 0 !c = return ()
+nTimes 0  _  = return ()
 nTimes !n !c = c >> nTimes (n-1) c
 
 

--- a/atomic-primops/testing/Counter.hs
+++ b/atomic-primops/testing/Counter.hs
@@ -7,16 +7,13 @@ import qualified Data.Atomics.Counter as C
 
 import Control.Monad
 import GHC.Conc
-import System.CPUTime
 import Test.Framework.Providers.HUnit (testCase)
-import Test.HUnit (Assertion, assertEqual, assertBool)
-import Text.Printf
-import Data.IORef  
+import Test.Framework(Test)
+import Test.HUnit (assertEqual)
 
 import CommonTesting (numElems, forkJoin, timeit, nTimes)
 
-name = "Unboxed"
-
+default_seq_tries, default_conc_tries :: Int
 default_seq_tries  = 10 * numElems
 -- Things are MUCH slower with contention:
 default_conc_tries = numElems
@@ -24,17 +21,20 @@ default_conc_tries = numElems
 --------------------------------------------------------------------------------
 -- Test the basics
 
+case_basic1 :: IO ()
 case_basic1 = do 
   r <- C.newCounter 0
   ret <- C.incrCounter 10 r
   assertEqual "incrCounter returns the NEW value" 10 ret
 
+case_basic2 :: IO ()
 case_basic2 = do 
   r <- C.newCounter 0
   t <- C.readCounterForCAS r
   (True,newt) <- C.casCounter r t 10
   assertEqual "casCounter returns new val/ticket on success" 10 (C.peekCTicket newt)
 
+case_basic3 :: IO ()
 case_basic3 = do 
   r <- C.newCounter 0
   t <- C.readCounterForCAS r
@@ -42,6 +42,7 @@ case_basic3 = do
   (False,oldt) <- C.casCounter r t 10
   assertEqual "casCounter returns read val on failure" 1 (C.peekCTicket oldt)
 
+case_basic4 :: IO ()
 case_basic4 = do 
   let tries = numElems `quot` 100
   r <- C.newCounter 0
@@ -55,8 +56,11 @@ case_basic4 = do
 --------------------------------------------------------------------------------
 -- Repeated increments
 
+incrloop :: Int -> IO Int
 incrloop tries = do r <- C.newCounter 0; nTimes tries $ void$ C.incrCounter 1 r
                     C.readCounter r
+
+case_incrloop :: IO ()
 case_incrloop = do 
    cnt <- incrloop default_seq_tries
    assertEqual "incrloop sum" default_seq_tries cnt
@@ -64,6 +68,7 @@ case_incrloop = do
 -- | Here we do a loop to test the unboxing of results from incrCounter:
 --   As of now [2013.07.19], it is successfully unboxing the results 
 --   for Data.Atomics.Counter.Unboxed.
+incrloop4B :: Int -> IO ()
 incrloop4B tries = do
   putStrLn " [incrloop4B] A test where we use the result of each incr."
   r <- C.newCounter 1
@@ -73,13 +78,14 @@ incrloop4B tries = do
    loop r 0 _ = do v <- C.readCounter r
                    putStrLn$"Final value: "++show v
                    return ()
-   loop r tries last = do
-     n <- C.incrCounter last r
+   loop r i l = do
+     n <- C.incrCounter l r
      if n == 2
-       then loop r (tries-1) 2
-       else loop r (tries-1) 1
+       then loop r (i-1) 2
+       else loop r (i-1) 1
 
 -- | Here we let the counter overflow, which seems to be causing problems.
+overflowTest :: Int -> IO ()
 overflowTest tries = do
   putStrLn " [incrloop4B] A test where we use the result of each incr."
   r <- C.newCounter 1
@@ -89,34 +95,38 @@ overflowTest tries = do
    loop r 0 _ = do v <- C.readCounter r
                    putStrLn$"Final value: "++show v
                    return ()
-   loop r tries last = do
-     putStrLn$ " [incrloop4B] Looping with tries left "++show tries 
-     n <- C.incrCounter last r
+   loop r i l = do
+     putStrLn$ " [incrloop4B] Looping with tries left "++show i 
+     n <- C.incrCounter l r
      -- This is HANGING afer passing 2,147,483,648.  (using Unboxed)
      -- Is there some defect wrt overflow?
      putStrLn$ " [incrloop4B] Done incr, received "++show n
-     loop r (tries-1) n
+     loop r (i-1) n
 
 --------------------------------------------------------------------------------
 -- Parallel repeated increments
 
 
 {-# INLINE parIncrloop #-} 
+parIncrloop :: (Int -> IO C.AtomicCounter)
+            -> (Int -> C.AtomicCounter -> IO Int) -> Int -> IO Int
 parIncrloop new incr iters = do
   numcap <- getNumCapabilities
   let (each,left) = iters `quotRem` numcap
   putStrLn$ "Concurrently incrementing counter from all "++show numcap++" threads, incrs per thread: "++show each
   r <- new 0
-  forkJoin numcap $ \ ix -> do
+  void $ forkJoin numcap $ \ ix -> do
     let mine = if ix==0 then each+left else each
     nTimes mine $ void $ incr 1 r
   C.readCounter r
 
+case_parincrloop :: IO ()
 case_parincrloop = do 
   cnt <- parIncrloop C.newCounter C.incrCounter default_conc_tries
   assertEqual "incrloop sum" default_conc_tries cnt
 
 -- | Use CAS instead of the real incr so we can compare the overhead.
+case_parincrloop_wCAS :: IO ()
 case_parincrloop_wCAS = do 
   cnt <- parIncrloop C.newCounter fakeIncr default_conc_tries
   assertEqual "incrloop sum" default_conc_tries cnt
@@ -131,18 +141,19 @@ case_parincrloop_wCAS = do
 
 --------------------------------------------------------------------------------
 
+tests :: [Test]
 tests = 
  [
-   testCase (name++"basic1_incrCounter") $ case_basic1
- , testCase (name++"basic2_casCounter") $ case_basic2
- , testCase (name++"basic3_casCounter") $ case_basic3
- , testCase (name++"basic4_casCounter") $ case_basic4
+   testCase "basic1_incrCounter" $ case_basic1
+ , testCase "basic2_casCounter" $ case_basic2
+ , testCase "basic3_casCounter" $ case_basic3
+ , testCase "basic4_casCounter" $ case_basic4
    ----------------------------------------
- , testCase (name++"_single_thread_repeat_incr") $ timeit case_incrloop
- , testCase (name++"_incr_with_result_feedback") $ timeit (incrloop4B default_seq_tries)
+ , testCase "single_thread_repeat_incr" $ timeit case_incrloop
+ , testCase "incr_with_result_feedback" $ timeit (incrloop4B default_seq_tries)
    ----------------------------------------
 
    -- Parallel versions:
- , testCase (name++"_concurrent_repeat_incr") $ void$ timeit case_parincrloop
- , testCase (name++"_concurrent_repeat_incrCAS") $ void$ timeit case_parincrloop_wCAS
+ , testCase "concurrent_repeat_incr" $ void$ timeit case_parincrloop
+ , testCase "concurrent_repeat_incrCAS" $ void$ timeit case_parincrloop_wCAS
  ]

--- a/atomic-primops/testing/Fetch.hs
+++ b/atomic-primops/testing/Fetch.hs
@@ -1,0 +1,219 @@
+module Fetch (tests) where
+
+-- tests for our fetch-and-* family of functions.
+import Control.Monad
+import Control.Applicative
+import System.Random
+import Test.Framework.Providers.HUnit (testCase)
+import Test.Framework (Test)
+import Test.HUnit (assertEqual,assertBool)
+import Data.Primitive
+import Data.List
+import Data.Bits
+import Data.Atomics
+import Control.Monad.Primitive
+import Control.Concurrent
+
+tests :: [Test]
+tests = [
+      testCase "Fetch-and-* operations return previous value" case_return_previous
+    , testCase "Fetch-and-* operations behave like their corresponding bitwise operators" case_like_bitwise
+    , testCase "Fetch-and-* operations are atomic" case_atomicity
+    ] 
+
+nand :: Bits a => a -> a -> a
+nand x y = complement (x .&. y)
+
+fetchOps :: [( String
+            ,  MutableByteArray RealWorld -> Int -> Int -> IO Int
+            ,  Int -> Int -> Int )]
+fetchOps = [
+   ("Add",  fetchAddIntArray,  (+)),
+   ("Sub",  fetchSubIntArray,  (-)),
+   ("And",  fetchAndIntArray,  (.&.)),
+   ("Nand", fetchNandIntArray, nand),
+   ("Or",   fetchOrIntArray,   (.|.)),
+   ("Xor",  fetchXorIntArray,  xor)
+   ]
+
+
+-- Test all operations at once, somewhat randomly, ensuring they behave like
+-- their corresponding bitwise operator; we compose a few operations before
+-- inspecting the intermediate result, and spread them randomly around a small
+-- array.
+-- TODO use quickcheck if we want
+case_like_bitwise :: IO ()
+case_like_bitwise = do
+    let opGroupSize = 5
+    let grp n = go n []
+          where go _ stck [] = [stck]
+                go 0 stck xs = stck : go n [] xs
+                go i stck (x:xs) = go (i-1) (x:stck) xs
+    -- Inf list of different short sequences of bitwise operations:
+    let opGroups = grp opGroupSize $ cycle $ concat $ permutations fetchOps
+    
+    let size = 4
+    randIxs <- randomRs (0, size-1) <$> newStdGen 
+    randArgs <- grp opGroupSize . randoms <$> newStdGen
+    
+    a <- newByteArray (sizeOf (undefined::Int) * size)
+    forM_ [0.. size-1] $ \ix-> writeByteArray a ix (0::Int)
+
+    forM_ (take 1000000 $ zip randIxs $ zipWith zip opGroups randArgs) $
+        \ (ix, opsArgs)-> do
+            assertEqual "test not b0rken" (length opsArgs) opGroupSize
+            
+            let doOpGroups pureLHS [] = return pureLHS
+                doOpGroups pureLHS (((_,atomicOp,op), v) : rest) = do
+                    atomicOp a ix v >> doOpGroups (pureLHS `op` v) rest
+                  
+            vInitial <- readByteArray a ix
+            vFinalPure <- doOpGroups vInitial opsArgs
+            vFinal <- readByteArray a ix
+
+            let nmsArgs = map (\ ((nm,_,_),v) -> (nm,v)) opsArgs
+            assertEqual ("sequence on initial value "++(show vInitial)
+                          ++" of ops with RHS args: "++(show nmsArgs)
+                          ++" gives same result in both pure and atomic op"
+                        ) vFinal vFinalPure
+
+              
+            
+-- check all operations return the value before the operation was applied;
+-- basic smoke test, with each op tested individually.
+case_return_previous :: IO ()
+case_return_previous = do
+    let l = length fetchOps
+    a <- newByteArray (sizeOf (undefined::Int) * l)
+    let randomInts = take l . randoms <$> newStdGen :: IO [Int]
+    initial <- randomInts
+    forM_ (zip [0..] initial) $ \(ix, v)-> writeByteArray a ix v
+
+    args <- randomInts
+    forM_ (zip4 [0..] initial args fetchOps) $ \(ix, pre, v, (nm,atomicOp,op))-> do
+        pre' <- atomicOp a ix v
+        assertEqual (fetchStr nm "returned previous value") pre pre'
+        let post = pre `op` v
+        post' <- readByteArray a ix
+        assertEqual (fetchStrArgVal nm v pre "operation was seen correctly on read") post post'
+
+fetchStr :: String -> String -> String
+fetchStr nm = (("fetch"++nm++"IntArray: ")++)
+fetchStrArgVal :: (Show a, Show a1) => String -> a -> a1 -> String -> String
+fetchStrArgVal nm v initial = (("fetch"++nm++"IntArray, with arg "++(show v)++" on value "++(show initial)++": ")++)
+
+-- ----------------------------------------------------------------------------
+-- Tests of atomicity:
+
+case_atomicity :: IO ()
+case_atomicity = do
+    fetchAndOrTest  10000000
+    fetchNandTest   1000000
+    fetchAddSubTest 10000000
+    fetchXorTest    10000000
+
+-- Concurrently run a sequence of AND and OR simultaneously on separate parts
+-- of the bit range of an Int.
+fetchAndOrTest :: Int -> IO ()
+fetchAndOrTest iters = do
+    out0 <- newEmptyMVar
+    out1 <- newEmptyMVar
+    mba <- newByteArray (sizeOf (undefined :: Int))
+    let andLowersBit , orRaisesBit :: Int -> Int
+        andLowersBit = clearBit (complement zeroBits)
+        orRaisesBit = setBit zeroBits
+    writeByteArray mba 0 (zeroBits :: Int)
+    -- thread 1 toggles bit 0, thread 2 toggles bit 1; then we verify results
+    -- in the main thread.
+    let go v b = do
+            outs <- replicateM iters $ do 
+                       low <- fetchOrIntArray mba 0 (orRaisesBit b)
+                       high <- fetchAndIntArray mba 0 (andLowersBit b)
+                       return (low,high)
+            putMVar v outs
+    void $ forkIO $ go out0 0
+    void $ forkIO $ go out1 1
+    res0 <- takeMVar out0
+    res1 <- takeMVar out1
+    let check b = all ( \(low,high)-> (not $ testBit low b) && testBit high b)
+
+    assertBool "fetchAndOrTest thread1" $ check 0 res0
+    assertBool "fetchAndOrTest thread2" $ check 1 res1
+
+-- Nand of 1 is a bit complement. Concurrently run two threads running an even
+-- number of complements in this way and verify the final value is unchanged.
+-- TODO think of a more clever test
+fetchNandTest :: Int -> IO ()
+fetchNandTest iters = do
+    let nandComplements = complement zeroBits
+        dblComplement mba = replicateM_ (2 * iters) $
+            fetchNandIntArray mba 0 nandComplements
+    randomInts <- take 10 . randoms <$> newStdGen :: IO [Int]
+    forM_ randomInts $ \ initial -> do
+        final <- race initial dblComplement dblComplement 
+        assertEqual "fetchNandTest" initial final
+
+
+-- ----------------------------------------------------------------------------
+-- Code below copied with minor modifications from GHC
+-- testsuite/tests/concurrent/should_run/AtomicPrimops.hs @ f293931
+-- ----------------------------------------------------------------------------
+
+
+-- | Test fetchAddIntArray# by having two threads concurrenctly
+-- increment a counter and then checking the sum at the end.
+fetchAddSubTest :: Int -> IO ()
+fetchAddSubTest iters = do
+    tot <- race 0
+        (\ mba -> work fetchAddIntArray mba iters 2)
+        (\ mba -> work fetchSubIntArray mba iters 1)
+    assertEqual "fetchAddSubTest" iters tot
+  where
+    work :: (MutableByteArray RealWorld -> Int -> Int -> IO Int) -> MutableByteArray RealWorld -> Int -> Int
+         -> IO ()
+    work _ _    0 _ = return ()
+    work op mba n val = op mba 0 val >> work op mba (n-1) val
+
+-- | Test fetchXorIntArray# by having two threads concurrenctly XORing
+-- and then checking the result at the end. Works since XOR is
+-- commutative.
+--
+-- Covers the code paths for AND, NAND, and OR as well.
+fetchXorTest :: Int -> IO ()
+fetchXorTest iters = do
+    res <- race n0
+        (\ mba -> work mba iters t1pat)
+        (\ mba -> work mba iters t2pat)
+    assertEqual "fetchXorTest" expected res
+  where
+    work :: MutableByteArray RealWorld -> Int -> Int -> IO ()
+    work _   0 _ = return ()
+    work mba n val = fetchXorIntArray mba 0 val >> work mba (n-1) val
+
+    -- Initial value is a large prime and the two patterns are 1010...
+    -- and 0101...
+    (n0, t1pat, t2pat)
+        -- TODO: If we want to silence warnings from here, use CPP conditional
+        --       on arch x86_64
+        | sizeOf (undefined :: Int) == 8 =
+            (0x00000000ffffffff, 0x5555555555555555, 0x9999999999999999)
+        | otherwise = (0x0000ffff, 0x55555555, 0x99999999)
+    expected
+        | sizeOf (undefined :: Int) == 8 = 4294967295
+        | otherwise = 65535
+
+-- | Create two threads that mutate the byte array passed to them
+-- concurrently. The array is one word large.
+race :: Int                    -- ^ Initial value of array element
+     -> (MutableByteArray RealWorld -> IO ())  -- ^ Thread 1 action
+     -> (MutableByteArray RealWorld -> IO ())  -- ^ Thread 2 action
+     -> IO Int                 -- ^ Final value of array element
+race n0 thread1 thread2 = do
+    done1 <- newEmptyMVar
+    done2 <- newEmptyMVar
+    mba <- newByteArray (sizeOf (undefined :: Int))
+    writeByteArray mba 0 n0
+    void $ forkIO $ thread1 mba >> putMVar done1 ()
+    void $ forkIO $ thread2 mba >> putMVar done2 ()
+    mapM_ takeMVar [done1, done2]
+    readByteArray mba 0

--- a/atomic-primops/testing/Issue28.hs
+++ b/atomic-primops/testing/Issue28.hs
@@ -1,11 +1,12 @@
 
 module Issue28 (main) where
 
-import Control.Monad
+-- import Control.Monad
 import Data.IORef
 import Data.Atomics
 -- import Data.Atomics.Internal (ptrEq)
 
+main :: IO ()
 main = do
   putStrLn "Issue28: Conducting the simplest possible read-then-CAS test."
   r <- newIORef "hi"
@@ -18,4 +19,3 @@ main = do
   -- unless (b1 == True) $ error "Test failed"  
 
   putStrLn$  "Issue28: test passed "++show t1
-  return ()

--- a/atomic-primops/testing/Test.hs
+++ b/atomic-primops/testing/Test.hs
@@ -22,7 +22,7 @@ import GHC.IORef
 import GHC.Stats (getGCStats, GCStats(..))
 import System.Random (randomIO, randomRIO)
 import Test.HUnit (Assertion, assertEqual, assertBool)
-import Test.Framework  (defaultMain)
+import Test.Framework  (defaultMain,testGroup,mutuallyExclusive)
 import Test.Framework.Providers.HUnit (testCase)
 import System.Mem (performGC)
 
@@ -54,8 +54,12 @@ main = do
        -- numcap <- getNumProcessors
        let numcap = 4
        when (numCapabilities /= numcap) $ setNumCapabilities numcap
-       
+
        defaultMain $ 
+        -- Make these run sequentially (hopefully), so we don't interfere with
+        -- concurrent tests. TODO I guess: figure out how to run tests that
+        -- don't fork in parallel, but forking tests sequentially
+        return $ mutuallyExclusive $ testGroup "All tests" $
          [ testCase "casTicket1"              case_casTicket1
          , testCase "issue28_standalone"      case_issue28_standalone
          , testCase "issue28_copied "         case_issue28_copied

--- a/atomic-primops/testing/Test.hs
+++ b/atomic-primops/testing/Test.hs
@@ -34,6 +34,7 @@ import qualified Issue28
 
 import CommonTesting 
 import qualified Counter
+import qualified Fetch
 
 ------------------------------------------------------------------------
 
@@ -89,6 +90,7 @@ main = do
          , iters   <- [10000]]
 
          ++ Counter.tests
+         ++ Fetch.tests
 
 setify :: [Int] -> [Int]
 setify = S.toList . S.fromList

--- a/atomic-primops/testing/test-atomic-primops.cabal
+++ b/atomic-primops/testing/test-atomic-primops.cabal
@@ -19,7 +19,7 @@ Flag threaded
 Test-Suite test-atomic-primops
     type:       exitcode-stdio-1.0
     main-is:    Test.hs
-    ghc-options: -rtsopts -main-is Test.main
+    ghc-options: -rtsopts -main-is Test.main -Wall
 
     if flag(opt)
        ghc-options: -O2 -funbox-strict-fields


### PR DESCRIPTION
Still waiting on discussion in #43, but if you want to merge this here it is.

@tibbe you might be interested in some of the tests in atomic-primops/testing/Fetch.hs for inclusion in the GHC testsuite: `fetchAndOrTest`, and to a lesser extent `fetchNandTest`