### PR TITLE
Fixes linking on windows

### DIFF
--- a/atomic-primops/Data/Atomics.hs
+++ b/atomic-primops/Data/Atomics.hs
@@ -447,7 +447,9 @@ loadLoadBarrier :: IO ()
 writeBarrier :: IO ()
 
 -- GHC 7.8 consistently exposes these symbols while linking:
-#if MIN_VERSION_base(4,7,0) && !defined(_WIN32) && !defined(_WIN64)
+
+#if MIN_VERSION_base(4,7,0) && !defined(mingw32_HOST_OS)
+
 foreign import ccall  unsafe "store_load_barrier" storeLoadBarrier
   :: IO ()
 

--- a/atomic-primops/atomic-primops.cabal
+++ b/atomic-primops/atomic-primops.cabal
@@ -122,6 +122,11 @@ Library
      C-Sources:        cbits/primops.cmm
      -- Duplicate RTS functionality for GHC 7.6:
      C-Sources:        cbits/RtsDup.c
+  } else {
+     if os(windows) {
+        Include-Dirs:     cbits
+        C-Sources:        cbits/RtsDup.c
+     }
   }
   CC-Options:       -Wall
 


### PR DESCRIPTION
Using 7.10.1 and 7.10.2 on windows, the GHC rts memory barrier functions
are unavailable. The code was trying to avoiding using these functions
but on my systems I had 2 problems:

* the _WIN32 and _WIN64 defines weren't present
* the cabal file was not building in RtsDup.c (once the defines were
changed)

For the defines, I used this page
(https://downloads.haskell.org/~ghc/7.10.2/docs/html/users_guide/options-phases.html#c-pre-processor)
and the command `stack exec ghc -- -E -optP-dM -cpp test.hs` to check
what was available.

And yeah, the cabal file just wasn't building the RtsDup file.