### PR TITLE
import Any from GHC.Base

### DIFF
--- a/atomic-primops/Data/Atomics/Internal.hs
+++ b/atomic-primops/Data/Atomics/Internal.hs
@@ -15,15 +15,15 @@ module Data.Atomics.Internal
    )
   where 
 
-import GHC.Base (Int(I#))
+import GHC.Base (Int(I#), Any)
 import GHC.Prim (RealWorld, Int#, State#, MutableArray#, MutVar#,
                  unsafeCoerce#, reallyUnsafePtrEquality#) 
 
 #if MIN_VERSION_base(4,7,0)
-import GHC.Prim (casArray#, casIntArray#, fetchAddIntArray#, Any, readMutVar#, casMutVar#)
+import GHC.Prim (casArray#, casIntArray#, fetchAddIntArray#, readMutVar#, casMutVar#)
 #elif MIN_VERSION_base(4,6,0)
 -- Any is only supported in the FFI in the way we need in GHC 7.6+
-import GHC.Prim (readMutVar#, Any, MutableByteArray#)
+import GHC.Prim (readMutVar#, MutableByteArray#)
 #else
 #error "Need to figure out how to emulate Any () in GHC <= 7.4 !"
 -- import GHC.Prim (Word#)


### PR DESCRIPTION
It got moved around in base-4.9/ghc-8.0, but this is a common point.

Built with ghc-8.1.20160330 (24d761531cfc18152598becc0aeb90376fd19198)

ping #55 