### PR TITLE
atomic-primops: Fix Setup.hs for current cabal versions

### DIFF
--- a/atomic-primops/Setup.hs
+++ b/atomic-primops/Setup.hs
@@ -1,22 +1,20 @@
 
 import Control.Monad (when)
-import Language.Haskell.TH
 import Distribution.Simple                (defaultMainWithHooks, simpleUserHooks, UserHooks(postConf), Args)
 import Distribution.Simple.Utils          (cabalVersion)
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.Setup          (ConfigFlags)
-import Distribution.Version               (Version(..))
+import Distribution.Version               (Version, mkVersion, versionNumbers)
 import Distribution.PackageDescription    (PackageDescription)
-import Debug.Trace
 
 -- I couldn't figure out a way to do this check from the cabal file, so we drop down
 -- here to do it instead:
 checkGoodVersion :: IO ()
 checkGoodVersion =
-  if   cabalVersion >= Version [1,17,0] []
+  if   cabalVersion >= mkVersion [1,17,0]
   then putStrLn (" [Setup.hs] This version of Cabal is ok for profiling: "++show cabalVersion)
   else error (" [Setup.hs] This package should not be used in profiling mode with cabal version "++
-                        show (versionBranch cabalVersion)++" < 1.17.0\n"++
+                        show (versionNumbers cabalVersion)++" < 1.17.0\n"++
                         " It will break, see cabal issue #1284")
 
 main :: IO ()


### PR DESCRIPTION
While trying to reproduce GHC #11444 on GHC master I found that this no longer
compiled due to improved encapsulation in the Cabal library.