### PR TITLE
Fix warnings (missing signatures, name shadowing, unused matches)

### DIFF
--- a/abstract-deque/Data/Concurrent/Deque/Debugger.hs
+++ b/abstract-deque/Data/Concurrent/Deque/Debugger.hs
@@ -52,9 +52,10 @@ instance PopL d => PopL (DebugDeque d) where
     tryPopL q 
 
 -- | Mark the last thread to use this endpoint.
+markThread :: Bool -> IORef (Maybe ThreadId) -> IO ()
 markThread True _ = return () -- Don't bother tracking.
 markThread False ref = do
-  last <- readIORef ref
+  _last <- readIORef ref
   tid  <- myThreadId
 --  putStrLn$"Marking! "++show tid
   atomicModifyIORef ref $ \ x ->


### PR DESCRIPTION
Fixes these errors:

```
Data/Concurrent/Deque/Debugger.hs:55:1: warning: [-Wmissing-signatures]
    Top-level binding with no type signature:
      markThread :: Bool -> IORef (Maybe ThreadId) -> IO ()

Data/Concurrent/Deque/Debugger.hs:57:3: warning: [-Wname-shadowing]
    This binding for ‘last’ shadows the existing binding
      imported from ‘Prelude’ at Data/Concurrent/Deque/Debugger.hs:6:8-37
      (and originally defined in ‘GHC.List’)

Data/Concurrent/Deque/Debugger.hs:57:3: warning: [-Wunused-matches]
    Defined but not used: ‘last’
```

I also don't see the purpose of the `_last <- readIORef ref` line - maybe it can be removed?