### PR TITLE
remove redundant dependencies from abstract-deque

### DIFF
--- a/abstract-deque/abstract-deque.cabal
+++ b/abstract-deque/abstract-deque.cabal
@@ -1,10 +1,10 @@
 Name:                abstract-deque
-Version:             0.3 
+Version:             0.3
 License:             BSD3
 License-file:        LICENSE
 Author:              Ryan R. Newton
 Maintainer:          rrnewton@gmail.com
-Category:            Data 
+Category:            Data
 Build-type:          Simple
 Cabal-version:       >= 1.18
 tested-with:         GHC == 8.4.3, GHC == 8.2.2, GHC == 8.0.2, GHC == 7.10.3
@@ -12,7 +12,7 @@ Homepage: https://github.com/rrnewton/haskell-lockfree/wiki
 Bug-Reports: https://github.com/rrnewton/haskell-lockfree/issues
 
 -- Version History:
--- 0.1: 
+-- 0.1:
 -- 0.1.1: Added nullQ to interface. [First release]
 -- 0.1.2: dependency on IORefCAS
 -- 0.1.3: Actually turned on real CAS! DANGER
@@ -30,10 +30,10 @@ Synopsis: Abstract, parameterized interface to mutable Deques.
 Description:
 
   An abstract interface to highly-parameterizable queues/deques.
-  . 
+  .
   Background: There exists a feature space for queues that extends between:
   .
-    * simple, single-ended, non-concurrent, bounded queues 
+    * simple, single-ended, non-concurrent, bounded queues
   .
     * double-ended, threadsafe, growable queues
   .

--- a/abstract-deque/abstract-deque.cabal
+++ b/abstract-deque/abstract-deque.cabal
@@ -61,9 +61,7 @@ Library
                      Data.Concurrent.Deque.Debugger
   build-depends:     base >= 4.8 && < 5
                    , array
-                   , random
                    , containers
-                   , time
   if flag(useCAS) && impl( ghc >= 7.4 ) && !os(mingw32) {
     build-depends:   atomic-primops >= 0.5.0.2
     cpp-options:  -DUSE_CAS -DDEFAULT_SIGNATURES

--- a/abstract-deque/abstract-deque.cabal
+++ b/abstract-deque/abstract-deque.cabal
@@ -60,7 +60,6 @@ Library
                      Data.Concurrent.Deque.Reference.DequeInstance,
                      Data.Concurrent.Deque.Debugger
   build-depends:     base >= 4.8 && < 5
-                   , array
                    , containers
   if flag(useCAS) && impl( ghc >= 7.4 ) && !os(mingw32) {
     build-depends:   atomic-primops >= 0.5.0.2

--- a/lockfree-queue/Data/Concurrent/Queue/MichaelScott.hs
+++ b/lockfree-queue/Data/Concurrent/Queue/MichaelScott.hs
@@ -21,7 +21,10 @@ module Data.Concurrent.Queue.MichaelScott
 
 import Data.IORef (readIORef, newIORef)
 import System.IO (stderr)
+
+#ifdef DEBUG
 import Data.ByteString.Char8 (hPutStrLn, pack)
+#endif
 
 -- import GHC.Types (Word(W#))
 import GHC.IORef(IORef(IORef))

--- a/lockfree-queue/lockfree-queue.cabal
+++ b/lockfree-queue/lockfree-queue.cabal
@@ -40,7 +40,6 @@ Library
   build-depends:     base >= 4.8 && < 5
                    , ghc-prim
                    , abstract-deque >= 0.3
-                   , bytestring
                    , atomic-primops >= 0.6
   -- Build failure on GHC 7.2:
   --                     queuelike


### PR DESCRIPTION
Removed dependencies on "random" and "time".

Question: Can we put the reference implementation under a flag so that we can drop the dependency on containers as well? Is the reference implementation actually supposed to be used in production?