### PR TITLE
Make tickets safe

### DIFF
--- a/atomic-primops/Data/Atomics/Counter.hs
+++ b/atomic-primops/Data/Atomics/Counter.hs
@@ -111,7 +111,7 @@ peekCTicket !x = x
 casCounter :: AtomicCounter -> CTicket -> Int -> IO (Bool, CTicket)
 -- casCounter (AtomicCounter barr) !old !new =
 casCounter (AtomicCounter mba#) (I# old#) newBox@(I# new#) = IO$ \s1# ->
-  let (# s2#, res# #) = casIntArray# mba# 0# old# new# s1# in
+  let !(# s2#, res# #) = casIntArray# mba# 0# old# new# s1# in
   case res# ==# old# of 
     False -> (# s2#, (False, I# res# ) #) -- Failure
     True  -> (# s2#, (True , newBox ) #) -- Success
@@ -130,12 +130,12 @@ casCounter (AtomicCounter mba#) (I# old#) newBox@(I# new#) = IO$ \s1# ->
 --   loop like CAS.
 incrCounter :: Int -> AtomicCounter -> IO Int
 incrCounter (I# incr#) (AtomicCounter mba#) = IO $ \ s1# -> 
-  let (# s2#, res #) = fetchAddIntArray# mba# 0# incr# s1# in
+  let !(# s2#, res #) = fetchAddIntArray# mba# 0# incr# s1# in
   (# s2#, (I# (res +# incr#)) #)
 
 {-# INLINE incrCounter_ #-}
 -- | An alternate version for when you don't care about the old value.
 incrCounter_ :: Int -> AtomicCounter -> IO ()
 incrCounter_ (I# incr#) (AtomicCounter mba#) = IO $ \ s1# -> 
-  let (# s2#, _ #) = fetchAddIntArray# mba# 0# incr# s1# in
+  let !(# s2#, _ #) = fetchAddIntArray# mba# 0# incr# s1# in
   (# s2#, () #)

--- a/atomic-primops/Data/Atomics/Internal.hs
+++ b/atomic-primops/Data/Atomics/Internal.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP, TypeSynonymInstances, BangPatterns #-}
 {-# LANGUAGE ForeignFunctionInterface, GHCForeignImportPrim, MagicHash, UnboxedTuples, UnliftedFFITypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 #define CASTFUN
 
@@ -9,24 +10,34 @@ module Data.Atomics.Internal
    (
     casIntArray#, fetchAddIntArray#,
     readForCAS#, casMutVarTicketed#, casArrayTicketed#,
+    readArrayElem#,
     Ticket,
-    -- * Very unsafe, not to be used
-    ptrEq
+    peekTicket,
+    seal,
+    -- * Very unsafe; for testing only
+    reallyUnsafeTicketEquality
    )
   where
 
 import GHC.Exts (Int(I#), Any, RealWorld, Int#, State#, MutableArray#, MutVar#,
-                 unsafeCoerce#, reallyUnsafePtrEquality#,
-                 casArray#, casIntArray#, fetchAddIntArray#, readMutVar#, casMutVar#)
+                 reallyUnsafePtrEquality#, readArray#,
+                 casArray#, casIntArray#, fetchAddIntArray#, readMutVar#, casMutVar#, lazy)
+import Data.Coerce (coerce)
 
 #ifdef DEBUG_ATOMICS
 {-# NOINLINE readForCAS# #-}
+{-# NOINLINE readArrayElem# #-}
 {-# NOINLINE casMutVarTicketed# #-}
 {-# NOINLINE casArrayTicketed# #-}
+{-# NOINLINE peekTicket #-}
+{-# NOINLINE seal #-}
 #else
--- {-# INLINE casMutVarTicketed# #-}
+{-# INLINE readForCAS# #-}
+{-# INLINE readArrayElem# #-}
+{-# INLINE casMutVarTicketed# #-}
 {-# INLINE casArrayTicketed# #-}
--- I *think* inlining may be ok here as long as casting happens on the arrow types:
+{-# INLINE peekTicket #-}
+{-# INLINE seal #-}
 #endif
 
 --------------------------------------------------------------------------------
@@ -34,50 +45,74 @@ import GHC.Exts (Int(I#), Any, RealWorld, Int#, State#, MutableArray#, MutVar#,
 --------------------------------------------------------------------------------
 
 -- | Unsafe, machine-level atomic compare and swap on an element within an Array.
-casArrayTicketed# :: MutableArray# RealWorld a -> Int# -> Ticket a -> Ticket a
+casArrayTicketed# :: forall a. MutableArray# RealWorld a -> Int# -> Ticket a -> Ticket a
           -> State# RealWorld -> (# State# RealWorld, Int#, Ticket a #)
 -- WARNING: cast of a function -- need to verify these are safe or eta expand.
-casArrayTicketed# = unsafeCoerce# casArray#
+casArrayTicketed# = coerce
+  ( casArray#
+      :: MutableArray# RealWorld a -> Int# -> a -> a
+      -> State# RealWorld -> (# State# RealWorld, Int#, a #) )
 
--- | When performing compare-and-swaps, the /ticket/ encapsulates proof
--- that a thread observed a specific previous value of a mutable
--- variable.  It is provided in lieu of the "old" value to
--- compare-and-swap.
+-- | Ordinary processor load instruction (non-atomic, not implying any memory barriers).
+readArrayElem# :: forall a . MutableArray# RealWorld a -> Int#
+  -> State# RealWorld -> (# State# RealWorld, Ticket a #)
+readArrayElem# = coerce
+  ( readArray#
+    :: MutableArray# RealWorld a -> Int#
+      -> State# RealWorld -> (# State# RealWorld, a #) )
+
+-- | When performing compare-and-swaps, the /ticket/ encapsulates proof that a
+-- thread observed a specific previous value of a mutable variable.  It is
+-- provided in lieu of the "old" value to compare-and-swap.
+-- A ticket should never be forced using 'seq' or otherwise. Doing so may "go
+-- back in time" and mess up the ticket from the moment of its creation
+-- so operations on it are likely to fail.
 --
 -- Design note: `Ticket`s exist to hide objects from the GHC compiler, which
--- can normally perform many optimizations that change pointer equality.  A Ticket,
--- on the other hand, is a first-class object that can be handled by the user,
--- but will not have its pointer identity changed by compiler optimizations
--- (but will of course, change addresses during garbage collection).
-newtype Ticket a = Ticket Any
--- If we allow tickets to be a pointer type, then the garbage collector will update
--- the pointer when the object moves.
+-- can normally perform many optimizations that change pointer equality.  A
+-- Ticket, on the other hand, is a first-class object that can be handled by
+-- the user, but will not have its pointer identity changed by compiler
+-- optimizations (but will of course, change addresses during garbage
+-- collection).
+newtype Ticket a = Ticket a
+-- If we allow tickets to be a pointer type, then the garbage collector will
+-- update the pointer when the object moves.
+
+-- | Wrap up a Haskell value in a ticket. This is not exposed "publicly" for
+-- now.  Presently the idea is that you must read from the mutable data
+-- structure itself to get a ticket.
+seal :: a -> Ticket a
+seal = Ticket
+
+-- | Extract a usable Haskell value from a ticket.
+peekTicket :: Ticket a -> a
+-- We use 'lazy' to guarantee that GHC's strictness analysis won't
+-- unbox the ticket if it sees that the result of `peekTicket`
+-- is eventually forced.
+peekTicket (Ticket a) = lazy a
 
 instance Show (Ticket a) where
   show _ = "<CAS_ticket>"
 
-{-# NOINLINE ptrEq #-}
-ptrEq :: a -> a -> Bool
-ptrEq !x !y = I# (reallyUnsafePtrEquality# x y) == 1
-
-instance Eq (Ticket a) where
-  (==) = ptrEq
+-- | Check whether the contents of two tickets are the
+-- same pointer. This is used only for testing.
+reallyUnsafeTicketEquality :: Ticket a -> Ticket a -> Bool
+reallyUnsafeTicketEquality x y = I# (reallyUnsafePtrEquality# x y) == 1
+{-# NOINLINE reallyUnsafeTicketEquality #-}
 
 --------------------------------------------------------------------------------
 
-readForCAS# :: MutVar# RealWorld a ->
+readForCAS# :: forall a. MutVar# RealWorld a ->
                State# RealWorld -> (# State# RealWorld, Ticket a #)
--- WARNING: cast of a function -- need to verify these are safe or eta expand:
-#ifdef CASTFUN
-readForCAS# = unsafeCoerce# readMutVar#
-#else
-readForCAS# mv rw =
-  case readMutVar# mv rw of
-    (# rw', a #) -> (# rw', unsafeCoerce# a #)
-#endif
+readForCAS# = coerce
+  ( readMutVar#
+      :: MutVar# RealWorld a ->
+               State# RealWorld -> (# State# RealWorld, a #) )
 
 
-casMutVarTicketed# :: MutVar# RealWorld a -> Ticket a -> Ticket a ->
+casMutVarTicketed# :: forall a. MutVar# RealWorld a -> Ticket a -> Ticket a ->
                State# RealWorld -> (# State# RealWorld, Int#, Ticket a #)
--- WARNING: cast of a function -- need to verify these are safe or eta expand:
-casMutVarTicketed# = unsafeCoerce# casMutVar#
+casMutVarTicketed# = coerce
+  ( casMutVar#
+      :: MutVar# RealWorld a -> a -> a ->
+               State# RealWorld -> (# State# RealWorld, Int#, a #) )

--- a/atomic-primops/testing/Test.hs
+++ b/atomic-primops/testing/Test.hs
@@ -32,6 +32,7 @@ import System.Mem (performGC)
 
 ----------------------------------------
 import Data.Atomics as A
+import Data.Atomics.Internal (reallyUnsafeTicketEquality)
 
 import qualified Issue28
 
@@ -158,7 +159,7 @@ test_random_array_comm threads size iters = do
   tick0 <- A.readArrayElem arr 0
   for_ 1 size $ \ i -> do
     t2 <- A.readArrayElem arr i
-    assertEqual "All initial Nothings in the array should be ticket-equal:" tick0 t2
+    assertBool "All initial Nothings in the array should be ticket-equal:" (reallyUnsafeTicketEquality tick0 t2)
 
   ls <- forkJoin threads $ \_tid -> do
     localAcc <- newIORef 0


### PR DESCRIPTION
* Use `lazy` instead of `unsafeCoerce#` to block up the optimizer.
  This should be much more robust under optimization as well as
  less prone to human error.

* Remove the utterly bogus `Eq` instance for tickets.

* Don't force tickets when checking pointer equality for them;
  while forcing usually makes sense for pointer equality,
  forcing tickets really never makes sense. And in the context
  where we do this, the values are all in normal form anyway.

* Add strictness annotations to get rid of warnings.

* Use `coerce` instead of `unsafeCoerce#` to change primop types to use tickets.

* Document that tickets should never be forced.

Fixes #5 