### PR TITLE
fix --flag=usecas build

### DIFF
--- a/abstract-deque/Data/Concurrent/Deque/Reference.hs
+++ b/abstract-deque/Data/Concurrent/Deque/Reference.hs
@@ -27,7 +27,7 @@ import Data.IORef
 
 #ifdef USE_CAS
 #warning "abstract-deque: reference implementation using CAS..."
-import Data.Atomic (atomicModifyIORefCAS)
+import Data.Atomics (atomicModifyIORefCAS)
 -- Toggle these and compare performance:
 modify = atomicModifyIORefCAS
 _is_using_CAS = True


### PR DESCRIPTION
Before the change the build against `atomic-primops-0.8.3` failed as:

```
Data/Concurrent/Deque/Reference.hs:30:1: error:
    Could not load module ‘Data.Atomic’
```

Bug: https://bugs.gentoo.org/750206