### PR TITLE
`lockfree-queue`: Fix the build with GHC 9.4

### DIFF
--- a/lockfree-queue/Data/Concurrent/Queue/MichaelScott.hs
+++ b/lockfree-queue/Data/Concurrent/Queue/MichaelScott.hs
@@ -35,13 +35,13 @@ import Data.Atomics (readForCAS, casIORef, Ticket, peekTicket)
 
 -- GHC 7.8 changed some primops
 import GHC.Base  hiding ((==#), sameMutVar#)
-import GHC.Prim hiding ((==#), sameMutVar#)
-import qualified GHC.PrimopWrappers as GPW
+import GHC.Exts hiding ((==#), sameMutVar#)
+import qualified GHC.Exts as Exts
 (==#) :: Int# -> Int# -> Bool
-(==#) x y = case x GPW.==# y of { 0# -> False; _ -> True }
+(==#) x y = case x Exts.==# y of { 0# -> False; _ -> True }
 
 sameMutVar# :: MutVar# s a -> MutVar# s a -> Bool
-sameMutVar# x y = case GPW.sameMutVar# x y of { 0# -> False; _ -> True }
+sameMutVar# x y = case Exts.sameMutVar# x y of { 0# -> False; _ -> True }
 
 
 -- Considering using the Queue class definition:


### PR DESCRIPTION
`sameMutVar#` is no longer provided by `GHC.PrimopWrappers`, but rather `GHC.Exts`. This patch changes the imports to use `GHC.Exts`, which both fixes the issue and should be more future-proof.

Fixes #83.