### PR TITLE
Approximate GHC's old atomic barriers with C11 fences

### DIFF
--- a/atomic-primops/CHANGELOG.md
+++ b/atomic-primops/CHANGELOG.md
@@ -1,3 +1,6 @@
+## next [????.??.??]
+* Allow building with GHC 9.10.
+
 ## 0.8.4 [2020.10.03]
 * Allow building with `base-4.15` (GHC 9.0).
 

--- a/atomic-primops/Data/Atomics.hs
+++ b/atomic-primops/Data/Atomics.hs
@@ -349,7 +349,24 @@ casMutVar2 mv tick new = IO$ \st ->
 -- | Memory barrier implemented by the GHC rts (see SMP.h).
 -- writeBarrier :: IO ()
 
-#if !(defined(mingw32_HOST_OS) && __GLASGOW_HASKELL__ < 802)
+#if __GLASGOW_HASKELL__ >= 909
+
+-- | A memory barrier that prevents future loads occurring before preceding
+-- stores.
+foreign import ccall  unsafe "hs_atomics_primops_store_load_barrier" storeLoadBarrier
+  :: IO ()
+
+-- | A memory barrier that prevents future loads occurring before earlier loads.
+foreign import ccall unsafe "hs_atomics_primops_load_load_barrier" loadLoadBarrier
+  :: IO ()
+
+-- | A memory barrier that prevents future stores occurring before preceding
+-- stores.
+foreign import ccall unsafe "hs_atomics_primops_write_barrier" writeBarrier
+  :: IO ()
+
+#elif !(defined(mingw32_HOST_OS) && __GLASGOW_HASKELL__ < 802)
+
 -- | Memory barrier implemented by the GHC rts (see SMP.h).
 foreign import ccall  unsafe "store_load_barrier" storeLoadBarrier
   :: IO ()

--- a/atomic-primops/atomic-primops.cabal
+++ b/atomic-primops/atomic-primops.cabal
@@ -1,13 +1,13 @@
+Cabal-version:       3.0
 Name:                atomic-primops
 Version:             0.8.4
-License:             BSD3
+License:             BSD-3-Clause
 License-file:        LICENSE
 Author:              Ryan Newton
 Maintainer:          rrnewton@gmail.com
 Category:            Data
 -- Portability:         non-portabile (x86_64)
 Build-type:          Simple
-Cabal-version:       1.18
 tested-with:         GHC == 8.4.3, GHC == 8.2.2, GHC == 8.0.2, GHC == 7.10.3
 HomePage: https://github.com/rrnewton/haskell-lockfree/wiki
 Bug-Reports: https://github.com/rrnewton/haskell-lockfree/issues
@@ -28,12 +28,13 @@ Description:
   This library is engineered to work pre- and post-GHC-7.8, while exposing the
   same interface.
 
-Extra-Source-Files:  CHANGELOG.md, DEVLOG.md,
-                     testing/Test.hs, testing/test-atomic-primops.cabal, testing/ghci-test.hs
-                     testing/Makefile, testing/CommonTesting.hs, testing/Counter.hs, testing/CounterCommon.hs, testing/hello.hs, testing/Fetch.hs
+Extra-Source-Files:  DEVLOG.md
+                     testing/Test.hs testing/test-atomic-primops.cabal testing/ghci-test.hs
+                     testing/Makefile testing/CommonTesting.hs testing/Counter.hs testing/CounterCommon.hs testing/hello.hs testing/Fetch.hs
                      testing/Issue28.hs
                      testing/TemplateHaskellSplices.hs
                      testing/Raw781_test.hs
+extra-doc-files:     CHANGELOG.md
 
 Flag debug
     Description: Enable extra internal checks.
@@ -50,6 +51,9 @@ Library
   build-depends:     base >= 4.8 && < 5
                    , ghc-prim
                    , primitive
+
+  if impl(ghc >= 9.9)
+    cmm-sources: cbits/atomics.cmm
 
   if os(windows) {
     Include-Dirs:     cbits

--- a/atomic-primops/cbits/atomics.cmm
+++ b/atomic-primops/cbits/atomics.cmm
@@ -1,0 +1,17 @@
+#include "Cmm.h"
+
+// These approximate GHC's old barrier operations in terms of the new C11-style
+// ordered atomic fences.
+
+hs_atomic_primops_store_load_barrier() {
+  prim %fence_seq_cst();
+}
+
+hs_atomic_primops_load_load_barrier() {
+  prim %fence_acquire();
+}
+
+hs_atomic_primops_write_barrier() {
+  prim %fence_release();
+}
+


### PR DESCRIPTION
As of GHC 9.9 the old-style Cmm atomic barriers have been removed. We now approximate them with C11 atomic fences. I believe these approximations should be at least as strong as the previous barriers.

Addresses #88.