### PR TITLE
atomic-primops: Add missing Cmm return statements

### DIFF
--- a/atomic-primops/cbits/atomics.cmm
+++ b/atomic-primops/cbits/atomics.cmm
@@ -5,13 +5,16 @@
 
 hs_atomic_primops_store_load_barrier() {
   prim %fence_seq_cst();
+  return ();
 }
 
 hs_atomic_primops_load_load_barrier() {
   prim %fence_acquire();
+  return ();
 }
 
 hs_atomic_primops_write_barrier() {
   prim %fence_release();
+  return ();
 }
 


### PR DESCRIPTION
See https://gitlab.haskell.org/ghc/ghc/-/issues/25010